### PR TITLE
Handle catch-all scanner POSTs

### DIFF
--- a/epicshop/package-lock.json
+++ b/epicshop/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "hasInstallScript": true,
       "dependencies": {
         "@epic-web/workshop-app": "^6.90.3",
         "@epic-web/workshop-utils": "^6.90.3",

--- a/epicshop/package.json
+++ b/epicshop/package.json
@@ -1,5 +1,8 @@
 {
   "type": "module",
+  "scripts": {
+    "postinstall": "node ./patch-workshop-app-router-noise.js"
+  },
   "dependencies": {
     "@epic-web/workshop-app": "^6.90.3",
     "@epic-web/workshop-utils": "^6.90.3",

--- a/epicshop/patch-workshop-app-router-noise.js
+++ b/epicshop/patch-workshop-app-router-noise.js
@@ -1,0 +1,71 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const serverBuildPath = path.join(
+	__dirname,
+	'node_modules/@epic-web/workshop-app/build/server/index.js',
+)
+
+const actionFunction = `async function action$catchAllNotFound() {
+  throw new Response("Not found", {
+    status: 404
+  });
+}
+`
+
+async function patchServerBuild() {
+	let source
+	try {
+		source = await fs.readFile(serverBuildPath, 'utf8')
+	} catch (error) {
+		if (error && typeof error === 'object' && 'code' in error) {
+			if (error.code === 'ENOENT') {
+				console.warn(
+					`Skipping workshop app router patch: ${serverBuildPath} was not found.`,
+				)
+				return
+			}
+		}
+		throw error
+	}
+
+	if (source.includes('action$catchAllNotFound')) {
+		console.log('Workshop app router patch already applied.')
+		return
+	}
+
+	const routeModuleBefore = `const route1 = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({
+  __proto__: null,
+  ErrorBoundary: ErrorBoundary$7,
+  default: $,
+  loader: loader$L
+}, Symbol.toStringTag, { value: "Module" }));`
+	const routeModuleAfter = `const route1 = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({
+  __proto__: null,
+  ErrorBoundary: ErrorBoundary$7,
+  default: $,
+  action: action$catchAllNotFound,
+  loader: loader$L
+}, Symbol.toStringTag, { value: "Module" }));`
+	const manifestBefore = `"routes/$": { "id": "routes/$", "parentId": "root", "path": "*", "index": void 0, "caseSensitive": void 0, "hasAction": false, "hasLoader": true`
+	const manifestAfter = `"routes/$": { "id": "routes/$", "parentId": "root", "path": "*", "index": void 0, "caseSensitive": void 0, "hasAction": true, "hasLoader": true`
+
+	if (!source.includes(routeModuleBefore)) {
+		throw new Error('Unable to find the root catch-all route module to patch.')
+	}
+	if (!source.includes(manifestBefore)) {
+		throw new Error('Unable to find the root catch-all route manifest to patch.')
+	}
+
+	const patchedSource = source
+		.replace(routeModuleBefore, routeModuleAfter)
+		.replace(manifestBefore, manifestAfter)
+		.replace('const $ = UNSAFE_withComponentProps', `${actionFunction}const $ = UNSAFE_withComponentProps`)
+
+	await fs.writeFile(serverBuildPath, patchedSource)
+	console.log('Patched workshop app catch-all route POST handling.')
+}
+
+await patchServerBuild()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a postinstall patch for the packaged workshop app server build so root catch-all `routes/$` has an action
- return a normal 404 response for non-GET requests to unknown catch-all paths instead of allowing React Router to raise `getInternalRouterError`
- keep the existing Sentry reporting path intact for real application errors

## Sentry
- epicshop EPICSHOP-F0 / 7447885629
- noisy scanner POST examples: `/RSC/...txt`, `/_next`, `/__rsc`, `/_next/image`, `/.action`, `/_rsc`, `/_middleware`

## Validation
- `npm run lint`
- `npm run typecheck`
- production server smoke: POST `/_next`, `/__rsc`, `/RSC/some-file.txt`, `/.action`, and `/_middleware` all returned 404 with no internal router error in the server log
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-df7c8f65-bf11-4ad9-a666-4e6fe8cb1a59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-df7c8f65-bf11-4ad9-a666-4e6fe8cb1a59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

